### PR TITLE
clk: microchip: fix bug - cannot refer to CLK_CCC_PLL1_OUT2/3

### DIFF
--- a/drivers/clk/microchip/clk-mpfs-ccc.c
+++ b/drivers/clk/microchip/clk-mpfs-ccc.c
@@ -156,7 +156,7 @@ static struct mpfs_ccc_out_hw_clock *mpfs_ccc_pllout_clks[] = {
 	mpfs_ccc_pll0out_clks, mpfs_ccc_pll1out_clks
 };
 
-static int mpfs_ccc_register_outputs(struct device *dev, struct mpfs_ccc_out_hw_clock *out_hws,
+static int mpfs_ccc_register_outputs(struct device *dev, size_t pll_index, struct mpfs_ccc_out_hw_clock *out_hws,
 				     unsigned int num_clks, struct mpfs_ccc_data *data,
 				     struct mpfs_ccc_pll_hw_clock *parent)
 {
@@ -170,7 +170,7 @@ static int mpfs_ccc_register_outputs(struct device *dev, struct mpfs_ccc_out_hw_
 			return -ENOMEM;
 
 		out_hw->divider.hw.init = CLK_HW_INIT_HW(name, &parent->hw, &clk_divider_ops, 0);
-		out_hw->divider.reg = data->pll_base[i / MPFS_CCC_OUTPUTS_PER_PLL] +
+		out_hw->divider.reg = data->pll_base[pll_index] +
 			out_hw->reg_offset;
 
 		ret = devm_clk_hw_register(dev, &out_hw->divider.hw);
@@ -218,7 +218,7 @@ static int mpfs_ccc_register_plls(struct device *dev, struct mpfs_ccc_pll_hw_clo
 
 		data->hw_data.hws[pll_hw->id] = &pll_hw->hw;
 
-		ret = mpfs_ccc_register_outputs(dev, mpfs_ccc_pllout_clks[i],
+		ret = mpfs_ccc_register_outputs(dev, i, mpfs_ccc_pllout_clks[i],
 						MPFS_CCC_OUTPUTS_PER_PLL, data, pll_hw);
 		if (ret)
 			return ret;

--- a/include/dt-bindings/clock/microchip,mpfs-clock.h
+++ b/include/dt-bindings/clock/microchip,mpfs-clock.h
@@ -54,18 +54,19 @@
 
 #define CLK_CCC_PLL0		0
 #define CLK_CCC_PLL1		1
-#define CLK_CCC_DLL0		2
-#define CLK_CCC_DLL1		3
 
-#define CLK_CCC_PLL0_OUT0	4
-#define CLK_CCC_PLL0_OUT1	5
-#define CLK_CCC_PLL0_OUT2	6
-#define CLK_CCC_PLL0_OUT3	7
+#define CLK_CCC_PLL0_OUT0	2
+#define CLK_CCC_PLL0_OUT1	3
+#define CLK_CCC_PLL0_OUT2	4
+#define CLK_CCC_PLL0_OUT3	5
 
-#define CLK_CCC_PLL1_OUT0	8
-#define CLK_CCC_PLL1_OUT1	9
-#define CLK_CCC_PLL1_OUT2	10
-#define CLK_CCC_PLL1_OUT3	11
+#define CLK_CCC_PLL1_OUT0	6
+#define CLK_CCC_PLL1_OUT1	7
+#define CLK_CCC_PLL1_OUT2	8
+#define CLK_CCC_PLL1_OUT3	9
+
+#define CLK_CCC_DLL0		10
+#define CLK_CCC_DLL1		11
 
 #define CLK_CCC_DLL0_OUT0	12
 #define CLK_CCC_DLL0_OUT1	13


### PR DESCRIPTION
* The bug fixed in this commit. CLK_CCC_PLL1_OUT2/3 cannot be refered in device-tree

* The cause of this bug and how to fix. CCC driver currently has no support for DLL.
However, CLK_CCC_DLL0/1 are defined before CLK_CCC_PLL0_OUT0. clk_data->hw_data.num equals to 10 (2 for PLL0/1, 8 for PLL0/1 output). Thus, CLK_CCC_PLL1_OUT2/3 which has index 10 and 11 will be considered invalid.
I moved DLL definitions to after PLL definitions.

Register base calculation in mpfs_ccc_register_outputs was also wrong. (i / MPFS_CCC_OUTPUTS_PER_PLL) is always evaluated as 0 which points to PLL0 because num_clks is 4.
Added pll_index as argument for mpfs_ccc_register_outputs.